### PR TITLE
Bump asciidoctor-epub3 to 1.5.0.alpha.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'asciidoctor', '1.5.6.2'
 gem 'json'
 gem 'awesome_print'
 
-gem 'asciidoctor-epub3', '~> 1.5.0.alpha.10'
+gem 'asciidoctor-epub3', '~> 1.5.0.alpha.11'
 gem 'asciidoctor-pdf', '~> 1.5.0.beta.8'
 gem 'asciidoctor-pdf-cjk', '~> 0.1.3'
 gem 'asciidoctor-pdf-cjk-kai_gen_gothic', '~> 0.1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'asciidoctor', '1.5.6.2'
 gem 'json'
 gem 'awesome_print'
 
-gem 'asciidoctor-epub3', '~> 1.5.0.alpha.9'
+gem 'asciidoctor-epub3', '~> 1.5.0.alpha.10'
 gem 'asciidoctor-pdf', '~> 1.5.0.beta.8'
 gem 'asciidoctor-pdf-cjk', '~> 0.1.3'
 gem 'asciidoctor-pdf-cjk-kai_gen_gothic', '~> 0.1.1'


### PR DESCRIPTION
Release notes for alpha-10: https://github.com/asciidoctor/asciidoctor-epub3/releases/tag/v1.5.0.alpha.10
Release notes for alpha-11: https://github.com/asciidoctor/asciidoctor-epub3/releases/tag/v1.5.0.alpha.11