### PR TITLE
Fail the build if expected tag already exists

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -121,9 +121,7 @@ end
 namespace :book do
   desc 'build basic book formats on Travis'
   task :build do
-
     repo = ENV['TRAVIS_REPO_SLUG']
-
     BookGenerator.build_book(repo)
   end
 
@@ -153,10 +151,10 @@ namespace :book do
                                   Time.now.utc.iso8601)
         begin
           @octokit.create_ref(repo, "tags/#{new_version}", obj.sha)
+          p "Created tag #{last_version}"
         rescue
-          p "the ref already exists ???"
+          raise "[ERROR] Can not create new tag #{new_version}. The ref already exists ???"
         end
-        p "Created tag #{last_version}"
       elsif (ENV['TRAVIS_TAG'])
         version = ENV['TRAVIS_TAG']
         changelog = GitHubChangelogGenerator.get_log do |config|


### PR DESCRIPTION
It's better to fail a build on `master` than silently mark it as successful when the desired tag already exists but not equal to the latest release.

The better way could be to overwrite the tag but I cannot find an appropriate option for `oktokit.create_tag` [method documentation](https://octokit.github.io/octokit.rb/Octokit/Client/Objects.html#create_tag-instance_method).